### PR TITLE
Remove railties 4.0 requirement to work with newer versions of rails

### DIFF
--- a/jsTimezoneDetect-rails.gemspec
+++ b/jsTimezoneDetect-rails.gemspec
@@ -19,5 +19,5 @@ Gem::Specification.new do |spec|
   spec.files         = Dir["{lib,vendor}/**/*"] + ["LICENSE.txt", "README.md"]
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency 'railties', '~> 4.0', '>= 4.0.0'
+  spec.add_runtime_dependency 'railties', '>= 4.0.0'
 end


### PR DESCRIPTION
Removed railties 4.0 requirement and left >= 4.0.0 so gem will work with rails 5